### PR TITLE
[AR-604] Preserve protocol from client request if not given in mirror list

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -83,15 +83,21 @@ def get_redirect(path, client_ip, mirror_class=mirror, dl_map=DL_MAP):
         del split_path[0:2]
         path = "{}".format("/".join(split_path))
 
+    """ prepend scheme from client request if not given by mirror url
+        allow schemes from 3 (ftp) to 5 (https) character length """
+    mirror_url = mirror_class.next(region)
+    if mirror_url.find('://', 3, 8) == -1
+        mirror_url = request.scheme + '://' + mirror_url
+
     if mirror_class.mode == "dl_map" and len(split_path) == 2:
         key = "{}/{}".format(split_path[0], split_path[1])
         new_path = dl_map.get(key, path)
-        return "{}{}".format(mirror_class.next(region), new_path)
+        return "{}{}".format(mirror_url, new_path)
 
     if path == '':
-        return mirror_class.next(region)
+        return mirror_url
 
-    return "{}{}".format(mirror_class.next(region), path)
+    return "{}{}".format(mirror_url, path)
 
 
 @app.route('/status')

--- a/app/mirrors.yaml
+++ b/app/mirrors.yaml
@@ -2,13 +2,13 @@
 mode: redirect
 mirrors:
   AS:
-    - https://mirrors.tuna.tsinghua.edu.cn/armbian/
+    - mirrors.tuna.tsinghua.edu.cn/armbian/
   NA:
-    - https://armbian.tnahosting.net/apt/
-    - https://us.mirrors.fossho.st/armbian/armbian/
+    - armbian.tnahosting.net/apt/
+    - us.mirrors.fossho.st/armbian/armbian/
   EU:
     #    - https://minio.k-space.ee/armbian/apt/
-    - https://uk.mirrors.fossho.st/armbian/apt/
-    - https://armbian.systemonachip.net/apt/
-    - http://mirrors.netix.net/armbian/apt/
-    - https://mirrors.dotsrc.org/armbian-apt/
+    - uk.mirrors.fossho.st/armbian/apt/
+    - armbian.systemonachip.net/apt/
+    - mirrors.netix.net/armbian/apt/
+    - mirrors.dotsrc.org/armbian-apt/


### PR DESCRIPTION
Currently redirects are done based on a mirror list with hardcoded URL scheme/protocol. This causes issues when either the client does not support the target protocol (e.g. no HTTPS support) or if the client does not allow its HTTPS request to be downgraded to plain HTTP, either in general or due to respected HSTS information. The usually expected behaviour for redirects is to preserve the protocol of the client request and in case leave HTTPS upgrades to be done by the target server.

This commit aims to implement that behaviour in an optional non-breaking way:
- If the protocol is given in the mirror list, it is used like before. This allows to force a protocol by the router, in case the mirror is not assured to support what the client requests. It is better to let the client decide whether to accept the protocol change or not, instead of letting it doing a request which is doomed to fail.
- If the protocol is not given in the mirror list, it is derived from the client's request scheme. This means that the mirror list needs to be changed for this commit to have any effect.

Closes #2
Related forum thread: https://forum.armbian.com/topic/18711-update-in-buster-is-failing-with-redirection-from-https-to-httparmbiantnahostingnetaptdistsbusterrelease-is-forbidden/
Ticket: [AR-604]

[AR-604]: https://armbian.atlassian.net/browse/AR-604