### PR TITLE
Remove the URL schemes from mirrors

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -86,7 +86,7 @@ def get_redirect(path, client_ip, mirror_class=mirror, dl_map=DL_MAP):
     """ prepend scheme from client request if not given by mirror url
         allow schemes from 3 (ftp) to 5 (https) character length """
     mirror_url = mirror_class.next(region)
-    if mirror_url.find('://', 3, 8) == -1
+    if mirror_url.find('://', 3, 8) == -1:
         mirror_url = request.scheme + '://' + mirror_url
 
     if mirror_class.mode == "dl_map" and len(split_path) == 2:

--- a/examples/mirrors-apt.yaml
+++ b/examples/mirrors-apt.yaml
@@ -2,13 +2,13 @@
 mode: redirect
 mirrors:
   AS:
-    - https://mirrors.tuna.tsinghua.edu.cn/armbian/
+    - mirrors.tuna.tsinghua.edu.cn/armbian/
   NA:
-    - https://armbian.tnahosting.net/apt/
-    - https://us.mirrors.fossho.st/armbian/apt/
+    - armbian.tnahosting.net/apt/
+    - us.mirrors.fossho.st/armbian/apt/
   EU:
     #    - https://minio.k-space.ee/armbian/apt/
-    - https://uk.mirrors.fossho.st/armbian/apt/
-    - https://armbian.systemonachip.net/apt/
-    - http://mirrors.netix.net/armbian/apt/
-    - https://mirrors.dotsrc.org/armbian-apt/
+    - uk.mirrors.fossho.st/armbian/apt/
+    - armbian.systemonachip.net/apt/
+    - mirrors.netix.net/armbian/apt/
+    - mirrors.dotsrc.org/armbian-apt/

--- a/examples/mirrors-dl.yaml
+++ b/examples/mirrors-dl.yaml
@@ -2,13 +2,13 @@
 mode: dl_map      
 mirrors:
   AS:
-    - https://mirrors.tuna.tsinghua.edu.cn/armbian-releases/
+    - mirrors.tuna.tsinghua.edu.cn/armbian-releases/
   NA:
-    - https://armbian.tnahosting.net/dl/
-    - https://us.mirrors.fossho.st/armbian/dl/
+    - armbian.tnahosting.net/dl/
+    - us.mirrors.fossho.st/armbian/dl/
   EU:
     - https://minio.k-space.ee/armbian/dl/
-    - https://uk.mirrors.fossho.st/armbian/dl/
-    - https://armbian.systemonachip.net/dl/
-    - http://mirrors.netix.net/armbian/dl/
-    - https://mirrors.dotsrc.org/armbian-dl/
+    - uk.mirrors.fossho.st/armbian/dl/
+    - armbian.systemonachip.net/dl/
+    - mirrors.netix.net/armbian/dl/
+    - mirrors.dotsrc.org/armbian-dl/


### PR DESCRIPTION
as of: https://github.com/armbian/dl-router/pull/14

And fix a syntax error introduced in this PR on the scheme check.