### PR TITLE
Append http:// if scheme is missing when dumping mirrors

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -117,8 +117,14 @@ def signal_reload():
 
 @app.route('/mirrors')
 def show_mirrors():
-    """ return all_mirrors in json format to requestor """
-    return json.dumps(mirror.all_mirrors())
+    """ return all_mirrors in json format to requestor
+    prepend http:// if no scheme is present """
+    mirror_list = mirror.all_mirrors()
+    for region in mirror_list.keys():
+        for i in range(len(mirror_list[region])):
+            if mirror_list[region][i].find('://', 3, 8) == -1:
+                mirror_list[region][i] = 'http://' + mirror_list[region][i]
+    return json.dumps(mirror_list)
 
 
 @app.route('/regions')


### PR DESCRIPTION
as the `armbian-config` mirror selector currently requires this, while schemes can be missing since https://github.com/armbian/dl-router/pull/14.

Again please test if this works, as I need to sleep now. I'll try to setup a test environment for this tomorrow to run tests myself on future PRs 🙂.

The thing here is whether my assumption is correct that the `yaml.load()` method creates `mirror_list` as Python dictionary (providing the `keys()` method to loop through the regions) while the contained regions values are Python lists to loop through via `range(len(...))`. Then the same is done as in #14 to check for a scheme, else add `http://` as of your advice.
**EDIT: According to the docs, that should all be correct: https://python.land/data-processing/python-yaml**