### PR TITLE
Add proto/scheme header test for /status entpoint

### DIFF
--- a/app/test_flask_app.py
+++ b/app/test_flask_app.py
@@ -1,13 +1,11 @@
-import os
-import tempfile
-import json
+from json import loads
 
 import pytest
 
 from main import app
 
 
-TEST_IPS = [ 
+TEST_IPS = [
         "10.0.0.1",
         "1.2.3.4",
         "123.254.123.233",
@@ -31,7 +29,7 @@ def test_mirrors(client):
     rv = client.get('/mirrors')
     jsondata = rv.data.decode('utf-8')
 
-    assert isinstance(json.loads(jsondata), dict)
+    assert isinstance(loads(jsondata), dict)
 
 def test_regions(client):
     """ test the regions endpoint """
@@ -39,7 +37,7 @@ def test_regions(client):
     rv = client.get('/regions')
     jsondata = rv.data.decode('utf-8')
 
-    assert isinstance(json.loads(jsondata), list)
+    assert isinstance(loads(jsondata), list)
 
 def test_regions_proxied(client):
     """ test the regions endpoint, but send x-forwarded-for headers """
@@ -50,17 +48,20 @@ def test_regions_proxied(client):
             }
         rv = client.get('/regions', headers=test_headers)
         jsondata = rv.data.decode('utf-8')
-        assert isinstance(json.loads(jsondata), list)
+        assert isinstance(loads(jsondata), list)
 
 def test_status_proxied(client):
-    """ test the status endpoint, but send x-forwarded-for headers 
-        the status endpoint sends an X-Client-IP header in the response
+    """ test the status endpoint, but send X-Forwarded-For and X-Forwarded-Proto headers
+        the status endpoint sends X-Client-IP and X-Request-Scheme headers in the response
         """
 
     for address in TEST_IPS:
         test_headers = {
             "X-Forwarded-For" : address,
+            "X-Forwarded-Proto" : "some",
             }
         rv = client.get('/status', headers=test_headers)
         assert 'X-Client-IP' in rv.headers
         assert rv.headers.get('X-Client-IP') == address
+        assert 'X-Request-Scheme' in rv.headers
+        assert rv.headers.get('X-Request-Scheme') == "some"


### PR DESCRIPTION
When the X-Forwarded-Proto request header is set, the /status endpoint is expected to send the related X-Request-Scheme response header.

Additionally this commit removes unused imports and two trailing spaces.