### PR TITLE
Add request scheme response header to redirects

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -163,7 +163,9 @@ def show_geoip(reader=geolite_reader):
 @app.route('/<path:path>')
 def catch_all(path):
     """ default app route for redirect """
-    return redirect(get_redirect(path, get_ip()), 302)
+    resp = redirect(get_redirect(path, get_ip()), 302)
+    resp.headers['X-Request-Scheme'] = get_scheme()
+    return resp
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is mainly for debugging: #22

If this is wanted in production, then it can be implemented more efficiently without calling `get_scheme()` two times. This is only a quick minimal way which does not affect any other function.